### PR TITLE
Support persistent 2.5 and 2.6

### DIFF
--- a/src/Yesod/Paginator.hs
+++ b/src/Yesod/Paginator.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE QuasiQuotes       #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts  #-}
@@ -76,7 +77,11 @@ paginateWith widget per items = do
     return (xs, widget p per tot)
 
 selectPaginated :: ( PersistEntity val
+#if MIN_VERSION_persistent(2, 5, 0)
+                   , PersistEntityBackend val ~ BaseBackend (YesodPersistBackend m)
+#else
                    , PersistEntityBackend val ~ YesodPersistBackend m
+#endif
                    , PersistQuery (YesodPersistBackend m)
                    , Yesod m
                    )
@@ -87,7 +92,11 @@ selectPaginated :: ( PersistEntity val
 selectPaginated = selectPaginatedWith defaultWidget
 
 selectPaginatedWith :: ( PersistEntity val
+#if MIN_VERSION_persistent(2, 5, 0)
+                       , PersistEntityBackend val ~ BaseBackend (YesodPersistBackend m)
+#else
                        , PersistEntityBackend val ~ YesodPersistBackend m
+#endif
                        , PersistQuery (YesodPersistBackend m)
                        , Yesod m
                        )


### PR DESCRIPTION
Tested on `lts-7.13` with ghc-8.0.2-rc2. (Because ghc 8.0.1 on macOS Sierra has a [bug](https://ghc.haskell.org/trac/ghc/ticket/12479).)