### PR TITLE
Paginator that works with backends other than persistent

### DIFF
--- a/src/Yesod/Paginator.hs
+++ b/src/Yesod/Paginator.hs
@@ -61,6 +61,7 @@ module Yesod.Paginator
     -- * Paginated data
     , Pages
     , pagesCurrent
+    , pageOffset
 
     -- * The current page
     , Page

--- a/src/Yesod/Paginator.hs
+++ b/src/Yesod/Paginator.hs
@@ -34,6 +34,23 @@
 --             |]
 -- @
 --
+-- For backends other than persitent @'selectCustom'@ can be used 
+--
+-- @
+-- getSomeRoute something = do
+--     (totCnt, pages) <- runDB $ 'selectCustom' 10 
+--                  someCntQuery 
+--                  (\pn -> someOffsetQuery $ 10 * (fromIntegral pn - 1))
+--
+--     defaultLayout $ do
+--         [whamlet|
+--             $forall thing <- 'pageItems' $ 'pagesCurrent' pages
+--                 ^{showThing $ entityVal thing}
+--
+--             ^{'simple' 5 pages}
+--             |]
+-- @
+
 module Yesod.Paginator
     (
     -- * Type-safe numerics
@@ -52,6 +69,7 @@ module Yesod.Paginator
     -- * Paginators
     , paginate
     , selectPaginated
+    , paginateCustom
 
     -- * Widgets
     , simple

--- a/src/Yesod/Paginator.hs
+++ b/src/Yesod/Paginator.hs
@@ -34,12 +34,12 @@
 --             |]
 -- @
 --
--- For backends other than persitent @'selectCustom'@ can be used 
+-- For backends other than persitent @'selectCustom'@ can be used
 --
 -- @
 -- getSomeRoute something = do
---     (totCnt, pages) <- runDB $ 'selectCustom' 10 
---                  someCntQuery 
+--     (totCnt, pages) <- runDB $ 'selectCustom' 10
+--                  someCntQuery
 --                  (\pn -> someOffsetQuery $ 10 * (fromIntegral pn - 1))
 --
 --     defaultLayout $ do

--- a/src/Yesod/Paginator/Paginate.hs
+++ b/src/Yesod/Paginator/Paginate.hs
@@ -53,14 +53,17 @@ paginate' per items p =
 -- than persistent. Allowing backend implementations like esqueleto.
 -- Needs only one runDB.
 -- Typically used with 't m ~ YesodDB site'
-paginateCustom :: (MonadTrans t, MonadHandler m, Monad (t m)) =>
-                     PerPage
-                     -> t m ItemsCount -> (PageNumber -> t m [a]) -> t m (ItemsCount, Pages a)
+paginateCustom
+    :: (MonadTrans t, MonadHandler m, Monad (t m))
+    => PerPage
+    -> t m ItemsCount
+    -> (PageNumber -> t m [a])
+    -> t m (ItemsCount, Pages a)
 paginateCustom per getcount getitems = do
-     cnt <- getcount 
-     p <- lift getCurrentPage
-     pitems <- getitems p
-     pure $ (cnt, toPages p per cnt pitems)
+    cnt <- getcount
+    p <- lift getCurrentPage
+    pitems <- getitems p
+    pure $ (cnt, toPages p per cnt pitems)
 
 
 -- | Paginate out of a persistent database

--- a/src/Yesod/Paginator/Paginate.hs
+++ b/src/Yesod/Paginator/Paginate.hs
@@ -7,6 +7,7 @@ module Yesod.Paginator.Paginate
     , paginate'
     , selectPaginated
     , selectPaginated'
+    , paginateCustom
     )
 where
 
@@ -46,6 +47,21 @@ paginate' per items p =
     toPages p per (genericLength items) $ genericTake per $ genericDrop
         (pageOffset p per)
         items
+
+
+-- | Generalized version of @'selectPaginated'@ that works with backends different
+-- than persistent. Allowing backend implementations like esqueleto.
+-- Needs only one runDB.
+-- Typically used with 't m ~ YesodDB site'
+paginateCustom :: (MonadTrans t, MonadHandler m, Monad (t m)) =>
+                     PerPage
+                     -> t m ItemsCount -> (PageNumber -> t m [a]) -> t m (ItemsCount, Pages a)
+paginateCustom per getcount getitems = do
+     cnt <- getcount 
+     p <- lift getCurrentPage
+     pitems <- getitems p
+     pure $ (cnt, toPages p per cnt pitems)
+
 
 -- | Paginate out of a persistent database
 selectPaginated

--- a/src/Yesod/Paginator/Paginate.hs
+++ b/src/Yesod/Paginator/Paginate.hs
@@ -63,7 +63,7 @@ paginateCustom per getcount getitems = do
     cnt <- getcount
     p <- lift getCurrentPage
     pitems <- getitems p
-    pure $ (cnt, toPages p per cnt pitems)
+    pure (cnt, toPages p per cnt pitems)
 
 
 -- | Paginate out of a persistent database


### PR DESCRIPTION
I added paginateCustom that is similar to selectPaginated but can work with 
backends like esqueleto. I kept the signature polymorphic in `m` but for something
like esqueleto the signature could be swapped to
```
paginateCustom :: (m ~ YesodDB site) =>  PerPage -> m ItemsCount -> (PageNumber -> m [a]) -> m (ItemsCount, Pages a)
```
since PageNumber numbering is 1 based, something like 
```
toOffset :: Num n => PerPage -> PageNumber -> n 
```
would be nice, but I have not included this one (should I?) and code using it needs to do something like
`fromIntegral pageNum - 1` when figuring out offset in the second query.
