### PR TITLE
Add instances to Page/Pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-11.11
+      - image: fpco/stack-build:lts-13.17
     steps:
       - checkout
       - restore_cache:

--- a/package.yaml
+++ b/package.yaml
@@ -46,9 +46,11 @@ tests:
     main: Spec.hs
     source-dirs: test
     dependencies:
+      - QuickCheck
       - hspec
-      - yesod-paginator
+      - quickcheck-classes
       - yesod-core
+      - yesod-paginator
       - yesod-test
   doctests:
     main: Main.hs

--- a/src/Yesod/Paginator/Pages.hs
+++ b/src/Yesod/Paginator/Pages.hs
@@ -57,6 +57,21 @@ data Page a = Page
     }
     deriving (Eq, Show)
 
+setPageItems :: Page a -> [b] -> Page b
+setPageItems page items = page { pageItems = items }
+
+overPageItems :: ([a] -> [b]) -> Page a -> Page b
+overPageItems f page = setPageItems page $ f $ pageItems page
+
+instance Functor Page where
+    fmap f = overPageItems $ fmap f
+
+instance Foldable Page where
+    foldMap f = foldMap f . pageItems
+
+instance Traversable Page where
+    traverse f page = setPageItems page <$> traverse f (pageItems page)
+
 -- | @'Page'@ constructor
 toPage :: [a] -> PageNumber -> Page a
 toPage = Page
@@ -68,6 +83,21 @@ data Pages a = Pages
     , pagesLast :: PageNumber
     }
     deriving (Eq, Show)
+
+setPagesCurrent :: Pages a -> Page b -> Pages b
+setPagesCurrent pages current = pages { pagesCurrent = current }
+
+overPagesCurrent :: (Page a -> Page b) -> Pages a -> Pages b
+overPagesCurrent f pages = setPagesCurrent pages $ f $ pagesCurrent pages
+
+instance Functor Pages where
+    fmap f = overPagesCurrent $ fmap f
+
+instance Foldable Pages where
+    foldMap f = foldMap f . pagesCurrent
+
+instance Traversable Pages where
+    traverse f pages = setPagesCurrent pages <$> traverse f (pagesCurrent pages)
 
 -- | Take previous pages, going back from current
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,5 @@
 ---
-resolver: lts-11.11
+resolver: lts-13.17
+extra-deps:
+  - quickcheck-classes-0.6.1.0@sha256:a8d0782eb2c67b6606eb4ff581f5813522b5b2e2ee91a9c2ae65bfc7d45b6327
+  - semirings-0.3.1.2@sha256:ecb57a0ba210409f1376646b3cfd1f48a756ad8ab8467fce98d50e2e15e1c528

--- a/test/Yesod/Paginator/PagesSpec.hs
+++ b/test/Yesod/Paginator/PagesSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Yesod.Paginator.PagesSpec
+    ( spec
+    )
+where
+
+import Data.Foldable (traverse_)
+import Data.Functor.Classes (Eq1(..), Show1(..))
+import Data.Proxy
+import Test.Hspec
+import Test.QuickCheck
+import Test.QuickCheck.Classes
+import Yesod.Paginator.Pages
+
+instance Arbitrary a => Arbitrary (Page a) where
+    arbitrary = (`toPage` 1) <$> arbitrary
+
+instance Arbitrary a => Arbitrary (Pages a) where
+    arbitrary = toPages 1 5 100 <$> arbitrary
+
+instance Eq1 Page where
+    liftEq f a b = liftEq f (pageItems a) (pageItems b)
+
+instance Show1 Page where
+    liftShowsPrec f g h = liftShowsPrec f g h . pageItems
+
+instance Arbitrary1 Page where
+    liftArbitrary = fmap (`toPage` 1) . liftArbitrary
+
+instance Eq1 Pages where
+    liftEq f a b = liftEq f (pagesCurrent a) (pagesCurrent b)
+
+instance Show1 Pages where
+    liftShowsPrec f g h = liftShowsPrec f g h . pagesCurrent
+
+instance Arbitrary1 Pages where
+    liftArbitrary = fmap (toPages 1 5 100) . liftArbitrary
+
+spec :: Spec
+spec = do
+    describe "Page" $ do
+        let proxyPage :: Proxy Page
+            proxyPage = Proxy
+
+        itPreserves $ functorLaws proxyPage
+        itPreserves $ foldableLaws proxyPage
+        itPreserves $ traversableLaws proxyPage
+
+    describe "Pages" $ do
+        let proxyPages :: Proxy Pages
+            proxyPages = Proxy
+
+        itPreserves $ functorLaws proxyPages
+        itPreserves $ foldableLaws proxyPages
+        itPreserves $ traversableLaws proxyPages
+
+itPreserves :: Laws -> Spec
+itPreserves Laws {..} = mkContext $ traverse_ (uncurry mkIt) lawsProperties
+  where
+    mkContext = context $ lawsTypeclass <> " laws"
+    mkIt name = it $ "preserves " <> name


### PR DESCRIPTION
These are useful so that you can paginate some table to a small page and then
query relations and attach them, while retaining the type as Pages of Page. It
is an N+1 query situation, but since you're pre-paginated it's fine.